### PR TITLE
feat: board-update boardPayload dto 적용하여 추가 

### DIFF
--- a/src/main/java/com/smallgolemduo/togethersee/controller/BoardController.java
+++ b/src/main/java/com/smallgolemduo/togethersee/controller/BoardController.java
@@ -47,10 +47,10 @@ public class BoardController {
         return boardService.findAll();
     }
 
-    @PutMapping("{boardId}")
+    @PutMapping("/{boardId}")
     public UpdateBoardResponse update(@PathVariable("boardId") Long id,
                                       @RequestBody @Valid UpdateBoardRequest updateBoardRequest) {
-        return boardService.updateBoard(id, updateBoardRequest);
+        return boardService.update(id, updateBoardRequest);
     }
 
     @DeleteMapping("/{boardId}")

--- a/src/main/java/com/smallgolemduo/togethersee/dto/request/UpdateBoardRequest.java
+++ b/src/main/java/com/smallgolemduo/togethersee/dto/request/UpdateBoardRequest.java
@@ -1,15 +1,24 @@
 package com.smallgolemduo.togethersee.dto.request;
 
+import com.smallgolemduo.togethersee.entity.Board;
 import com.smallgolemduo.togethersee.entity.enums.MovieType;
 import lombok.*;
+
+import javax.validation.constraints.Size;
 
 @Getter
 @Builder
 @AllArgsConstructor
 public class UpdateBoardRequest {
 
+    private static final Long DEFAULT_VALUE = 0L;
+
+    @Size(min = 2, max = 50, message = "제목은 2-50자 사이입니다.")
     private String title;
+
+    @Size(min = 2, max = 500, message = "내용은 2-500자 사이입니다.")
     private String content;
+
     private MovieType movieType;
 
 }

--- a/src/main/java/com/smallgolemduo/togethersee/dto/response/UpdateBoardResponse.java
+++ b/src/main/java/com/smallgolemduo/togethersee/dto/response/UpdateBoardResponse.java
@@ -1,7 +1,6 @@
 package com.smallgolemduo.togethersee.dto.response;
 
-import com.smallgolemduo.togethersee.entity.Board;
-import com.smallgolemduo.togethersee.entity.enums.MovieType;
+import com.smallgolemduo.togethersee.dto.BoardPayload;
 import lombok.*;
 
 @Getter
@@ -9,21 +8,11 @@ import lombok.*;
 @AllArgsConstructor
 public class UpdateBoardResponse {
 
-    private Long id;
-    private String title;
-    private String content;
-    private Long likes;
-    private Long dislikes;
-    private MovieType movieType;
+    private BoardPayload boardPayload;
 
-    public static UpdateBoardResponse from(Board board) {
+    public static UpdateBoardResponse from(BoardPayload boardPayload) {
         return UpdateBoardResponse.builder()
-                .id(board.getId())
-                .title(board.getTitle())
-                .content(board.getContent())
-                .likes(board.getLikes())
-                .dislikes(board.getDislikes())
-                .movieType(board.getMovieType())
+                .boardPayload(boardPayload)
                 .build();
     }
 

--- a/src/main/java/com/smallgolemduo/togethersee/entity/Board.java
+++ b/src/main/java/com/smallgolemduo/togethersee/entity/Board.java
@@ -30,10 +30,4 @@ public class Board {
 //    @OneToMany(mappedBy = "board", fetch = FetchType.LAZY)
 //    private List<Comment> comments = new ArrayList<>();
 
-    public void modifyBoardInfo(String title, String content, MovieType movieType) {
-        this.title = title;
-        this.content = content;
-        this.movieType = movieType;
-    }
-
 }

--- a/src/main/java/com/smallgolemduo/togethersee/service/BoardService.java
+++ b/src/main/java/com/smallgolemduo/togethersee/service/BoardService.java
@@ -47,14 +47,19 @@ public class BoardService {
     }
 
     @Transactional
-    public UpdateBoardResponse updateBoard(Long id, UpdateBoardRequest updateBoardRequest) {
+    public UpdateBoardResponse update(Long id, UpdateBoardRequest updateBoardRequest) {
         Board board = boardRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("작성된 게시물이 없습니다."));
-        board.modifyBoardInfo(
-                updateBoardRequest.getTitle(),
-                updateBoardRequest.getContent(),
-                updateBoardRequest.getMovieType());
-        return UpdateBoardResponse.from(boardRepository.save(board));
+        if (updateBoardRequest.getTitle() != null) {
+            board.setTitle(updateBoardRequest.getTitle());
+        }
+        if (updateBoardRequest.getContent() != null) {
+            board.setContent(updateBoardRequest.getContent());
+        }
+        if (updateBoardRequest.getMovieType() != null) {
+            board.setMovieType(updateBoardRequest.getMovieType());
+        }
+        return UpdateBoardResponse.from(BoardPayload.from(boardRepository.save(board)));
     }
 
     @Transactional

--- a/src/test/java/com/smallgolemduo/togethersee/controller/BoardControllerTest.java
+++ b/src/test/java/com/smallgolemduo/togethersee/controller/BoardControllerTest.java
@@ -128,142 +128,33 @@ class BoardControllerTest {
                 .andExpect(jsonPath("$[1].boardPayloads[0].userId").value(1L))
                 .andDo(print());
     }
-//
-//    @Test
-//    @DisplayName("게시글 전체 수정")
-//    void update_all() throws Exception {
-//        // given
-//        Long boardId = 1L;
-//        UpdateBoardRequest boardRequest = new UpdateBoardRequest("새로운 제목", "새로운 내용",
-//                "새로운 작성자", Genre.ETC);
-//        UpdateBoardResponse boardResponse = new UpdateBoardResponse(1L, "새로운 제목", "새로운 내용",
-//                "새로운 작성자", 1L, 3L, Genre.ETC);
-//        given(boardService.update(any(), any())).willReturn(boardResponse);
-//
-//        // when & then
-//        String writeValueAsString = objectMapper.writeValueAsString(boardRequest);
-//        mockMvc.perform(put("/api/boards/{boardId}", boardId)
-//                        .contentType(MediaType.APPLICATION_JSON)
-//                        .content(writeValueAsString))
-//                .andExpect(status().isOk())
-//                .andExpect(jsonPath("$.id").value(1L))
-//                .andExpect(jsonPath("$.title").value("새로운 제목"))
-//                .andExpect(jsonPath("$.content").value("새로운 내용"))
-//                .andExpect(jsonPath("$.author").value("새로운 작성자"))
-//                .andExpect(jsonPath("$.likes").value(1L))
-//                .andExpect(jsonPath("$.dislikes").value(3L))
-//                .andExpect(jsonPath("$.genre").value("ETC"))
-//                .andDo(print());
-//    }
-//
-//    @Test
-//    @DisplayName("게시글 제목 수정")
-//    void update_title() throws Exception {
-//        // given
-//        Long boardId = 2L;
-//        UpdateBoardRequest boardRequest = new UpdateBoardRequest("제목", "안녕",
-//                "최성욱", Genre.ACTION);
-//        UpdateBoardResponse boardResponse = new UpdateBoardResponse(boardId, "새로운 제목", "안녕",
-//                "최성욱", 1L, 2L, Genre.ACTION);
-//        given(boardService.update(any(), any())).willReturn(boardResponse);
-//
-//        //when & than
-//        String writeValueAsString = objectMapper.writeValueAsString(boardRequest);
-//        mockMvc.perform(put("/api/boards/{boardId}", boardId)
-//                        .contentType(MediaType.APPLICATION_JSON)
-//                        .content(writeValueAsString))
-//                .andExpect(status().isOk())
-//                .andExpect(jsonPath("$.id").value(2L))
-//                .andExpect(jsonPath("$.title").value("새로운 제목"))
-//                .andExpect(jsonPath("$.content").value("안녕"))
-//                .andExpect(jsonPath("$.author").value("최성욱"))
-//                .andExpect(jsonPath("$.likes").value(1L))
-//                .andExpect(jsonPath("$.dislikes").value(2L))
-//                .andExpect(jsonPath("$.genre").value("ACTION"))
-//                .andDo(print());
-//    }
-//
-//    @Test
-//    @DisplayName("게시글 내용 수정")
-//    void update_content() throws Exception {
-//        // given
-//        Long boardId = 3L;
-//        UpdateBoardRequest boardRequest = new UpdateBoardRequest("제목", "안녕",
-//                "최성욱", Genre.ACTION);
-//        UpdateBoardResponse boardResponse = new UpdateBoardResponse(boardId, "제목", "새로운 내용",
-//                "최성욱", 1L, 2L, Genre.ACTION);
-//        given(boardService.update(any(), any())).willReturn(boardResponse);
-//
-//        //when & than
-//        String writeValueAsString = objectMapper.writeValueAsString(boardRequest);
-//        mockMvc.perform(put("/api/boards/{boardId}", boardId)
-//                        .contentType(MediaType.APPLICATION_JSON)
-//                        .content(writeValueAsString))
-//                .andExpect(status().isOk())
-//                .andExpect(jsonPath("$.id").value(3L))
-//                .andExpect(jsonPath("$.title").value("제목"))
-//                .andExpect(jsonPath("$.content").value("새로운 내용"))
-//                .andExpect(jsonPath("$.author").value("최성욱"))
-//                .andExpect(jsonPath("$.likes").value(1L))
-//                .andExpect(jsonPath("$.dislikes").value(2L))
-//                .andExpect(jsonPath("$.genre").value("ACTION"))
-//                .andDo(print());
-//    }
-//
-//    @Test
-//    @DisplayName("게시글 작성자 수정")
-//    void update_author() throws Exception {
-//        // given
-//        Long boardId = 4L;
-//        UpdateBoardRequest boardRequest = new UpdateBoardRequest("제목", "내용",
-//                "최성욱", Genre.ACTION);
-//        UpdateBoardResponse boardResponse = new UpdateBoardResponse(boardId, "제목", "내용",
-//                "새로운 작성자", 1L, 2L, Genre.ACTION);
-//        given(boardService.update(any(), any())).willReturn(boardResponse);
-//
-//        //when & than
-//        String writeValueAsString = objectMapper.writeValueAsString(boardRequest);
-//        mockMvc.perform(put("/api/boards/{boardId}", boardId)
-//                        .contentType(MediaType.APPLICATION_JSON)
-//                        .content(writeValueAsString))
-//                .andExpect(status().isOk())
-//                .andExpect(jsonPath("$.id").value(4L))
-//                .andExpect(jsonPath("$.title").value("제목"))
-//                .andExpect(jsonPath("$.content").value("내용"))
-//                .andExpect(jsonPath("$.author").value("새로운 작성자"))
-//                .andExpect(jsonPath("$.likes").value(1L))
-//                .andExpect(jsonPath("$.dislikes").value(2L))
-//                .andExpect(jsonPath("$.genre").value("ACTION"))
-//                .andDo(print());
-//    }
-//
-//    @Test
-//    @DisplayName("게시글 장르 수정")
-//    void update_genre() throws Exception {
-//        // given
-//        Long boardId = 5L;
-//        UpdateBoardRequest boardRequest = new UpdateBoardRequest("제목", "안녕",
-//                "최성욱", Genre.ACTION);
-//        UpdateBoardResponse boardResponse = new UpdateBoardResponse(boardId, "제목", "새로운 내용",
-//                "최성욱", 1L, 2L, Genre.SF_FANTASY);
-//        given(boardService.update(any(), any())).willReturn(boardResponse);
-//
-//        //when & than
-//        String writeValueAsString = objectMapper.writeValueAsString(boardRequest);
-//        mockMvc.perform(put("/api/boards/{boardId}", boardId)
-//                        .contentType(MediaType.APPLICATION_JSON)
-//                        .content(writeValueAsString))
-//                .andExpect(status().isOk())
-//                .andExpect(jsonPath("$.id").value(5L))
-//                .andExpect(jsonPath("$.title").value("제목"))
-//                .andExpect(jsonPath("$.content").value("새로운 내용"))
-//                .andExpect(jsonPath("$.author").value("최성욱"))
-//                .andExpect(jsonPath("$.likes").value(1L))
-//                .andExpect(jsonPath("$.dislikes").value(2L))
-//                .andExpect(jsonPath("$.genre").value("SF_FANTASY"))
-//                .andDo(print());
-//    }
-//
+
+    @Test
+    @DisplayName("게시글 수정")
+    void update() throws Exception {
+        // given
+        Long boardId = 1L;
+        UpdateBoardRequest boardRequest = new UpdateBoardRequest("새로운 제목", "새로운 내용", ETC);
+        UpdateBoardResponse boardResponse = new UpdateBoardResponse(
+                new BoardPayload(
+                        1L, "새로운 제목", "새로운 내용", 1L, 3L, ETC, 1L));
+        given(boardService.update(any(), any())).willReturn(boardResponse);
+
+        // when & then
+        String writeValueAsString = objectMapper.writeValueAsString(boardRequest);
+        mockMvc.perform(put("/api/boards/{boardId}", boardId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(writeValueAsString))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.boardPayload.id").value(1L))
+                .andExpect(jsonPath("$.boardPayload.title").value("새로운 제목"))
+                .andExpect(jsonPath("$.boardPayload.content").value("새로운 내용"))
+                .andExpect(jsonPath("$.boardPayload.likes").value(1L))
+                .andExpect(jsonPath("$.boardPayload.dislikes").value(3L))
+                .andExpect(jsonPath("$.boardPayload.movieType").value("ETC"))
+                .andDo(print());
+    }
+
 //    @Test
 //    @DisplayName("게시글 삭제")
 //    void deleted() throws Exception {

--- a/src/test/java/com/smallgolemduo/togethersee/service/BoardServiceTest.java
+++ b/src/test/java/com/smallgolemduo/togethersee/service/BoardServiceTest.java
@@ -26,6 +26,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
 import java.util.Optional;
+import java.util.Random;
 
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doNothing;
@@ -84,7 +85,7 @@ class BoardServiceTest {
     @DisplayName("게시글 조회")
     void findById() {
         // given
-        Long boardId = 5L;
+        Long boardId = new Random().nextLong();
         Board board = Board.builder()
                 .id(boardId).title("이거 재밌네").content("극한직업").likes(1L)
                 .dislikes(1L).movieType(ROMANCE_COMEDY).user(User.builder()
@@ -136,45 +137,37 @@ class BoardServiceTest {
         assertThat(findAllBoardResponses).usingRecursiveComparison().isEqualTo(expectedValue);
     }
 
+    @Test
+    @DisplayName("게시글 수정")
+    void update() {
+        // given
+        Long boardId = new Random().nextLong();
+        User user = User.builder()
+                .id(1L).username("성욱").email("asd@naver.com")
+                .password("1234").birth("950928").phoneNumber("010-1234-1234").boards(List.of())
+                .build();
+        Board board = Board.builder()
+                .id(boardId).title("제목입니다").content("내용입니다")
+                .likes(1L).dislikes(2L).movieType(DRAMA_DOCUMENTARY).user(user)
+                .build();
+        given(boardRepository.findById(any())).willReturn(Optional.ofNullable(board));
 
-//    @DisplayName("게시글 수정")
-//    void update() {
-//        // given
-//        Long boardId = 1L;
-//        Board board = Board.builder()
-//                .id(boardId)
-//                .title("제목입니다")
-//                .content("내용입니다")
-//                .author("최성욱")
-//                .likes(1L)
-//                .dislikes(2L)
-//                .genre(Genre.DRAMA_DOCUMENTARY)
-//                .userId(3L)
-//                .build();
-//        given(boardRepository.findById(any())).willReturn(Optional.ofNullable(board));
-//        Board modifyBoard = Board.builder()
-//                .id(boardId)
-//                .title("새로운 제목")
-//                .content("새로운 내용")
-//                .author("새로운 작성자")
-//                .likes(1L)
-//                .dislikes(2L)
-//                .genre(Genre.DRAMA_DOCUMENTARY)
-//                .userId(3L)
-//                .build();
-//        given(boardRepository.save(any())).willReturn(modifyBoard);
-//        UpdateBoardRequest boardRequest = new UpdateBoardRequest(
-//                "새로운 제목", "새로운 내용", "새로운 작성자", Genre.DRAMA_DOCUMENTARY);
-//        UpdateBoardResponse boardResponse = new UpdateBoardResponse(
-//                boardId, "새로운 제목", "새로운 내용", "새로운 작성자", 1L, 2L,
-//                Genre.DRAMA_DOCUMENTARY);
-//
-//        // when
-//        UpdateBoardResponse expectedUpdateBoardResponse = boardService.update(boardId, boardRequest);
-//
-//        // then
-//        assertThat(boardResponse).usingRecursiveComparison().isEqualTo(expectedUpdateBoardResponse);
-//    }
+        Board updateBoard = Board.builder()
+                .id(boardId).title("새로운 제목").content("새로운 내용")
+                .likes(1L).dislikes(2L).movieType(ACTION).user(user)
+                .build();
+        given(boardRepository.save(any())).willReturn(updateBoard);
+        UpdateBoardRequest updateBoardRequest = new UpdateBoardRequest("새로운 제목", "새로운 내용", ACTION);
+        UpdateBoardResponse expectedBoardResponse = new UpdateBoardResponse(
+                new BoardPayload(boardId, "새로운 제목", "새로운 내용", 1L, 2L,
+                        ACTION, 1L));
+
+        // when
+        UpdateBoardResponse updateBoardResponse = boardService.update(boardId, updateBoardRequest);
+
+        // then
+        assertThat(updateBoardResponse).usingRecursiveComparison().isEqualTo(expectedBoardResponse);
+    }
 //
 //    @Test
 //    @DisplayName("게시글 삭제")


### PR DESCRIPTION
1. Board
- modifyBoardInfo() 메서드 제거
2. BoardController
- url 수정
- updateBoard() -> update() 메서드명 수정
3. BoardService
- updateBoard() -> update() 메서드명 수정
- 요청 받은 데이터 null 인지 확인하는 코드 추가
4. UpdateBoardRequest
- title, content -> @SiZe 어노테이션 추가
5. UpdateBoardResponse
- boardPayload 추가